### PR TITLE
Add category function

### DIFF
--- a/src/djy/char.clj
+++ b/src/djy/char.clj
@@ -179,6 +179,13 @@
     (Character/getName (code-point-of ch)))
 )
 
+(defn category-int
+  "Returns an integer value indicating the general category of the given character or code
+   point."
+  {:added "1.6"}
+  [ch]
+  (Character/getType ^long (code-point-of ch)))
+
 ;;; Boolean functions ;;;
 
 (defn defined?
@@ -319,7 +326,7 @@
          Character/START_PUNCTUATION, Character/END_PUNCTUATION,
          Character/INITIAL_QUOTE_PUNCTUATION, Character/FINAL_QUOTE_PUNCTUATION,
          Character/OTHER_PUNCTUATION}
-       (Character/getType ^long (code-point-of ch))))
+       (category-int ch)))
 
 (defn mark?
   "Determines whether a character or code point is a mark character, according to the
@@ -328,7 +335,7 @@
   [ch]
   (in? #{Character/COMBINING_SPACING_MARK, Character/ENCLOSING_MARK,
          Character/NON_SPACING_MARK}
-       (Character/getType ^long (code-point-of ch))))
+       (category-int ch)))
 
 (defn symbol?
   "Determines whether a character or code point is a symbol character, according to the
@@ -337,7 +344,7 @@
   [ch]
   (in? #{Character/MATH_SYMBOL, Character/CURRENCY_SYMBOL,
          Character/MODIFIER_SYMBOL, Character/OTHER_SYMBOL}
-       (Character/getType ^long (code-point-of ch))))
+       (category-int ch)))
 
 (defn separator?
   "Determines whether a character or code point is a separator, according to the Unicode
@@ -346,7 +353,7 @@
   [ch]
   (in? #{Character/LINE_SEPARATOR, Character/PARAGRAPH_SEPARATOR,
          Character/SPACE_SEPARATOR}
-       (Character/getType ^long (code-point-of ch))))
+       (category-int ch)))
 
 
 (defn lower-case?

--- a/src/djy/char.clj
+++ b/src/djy/char.clj
@@ -186,6 +186,50 @@
   [ch]
   (Character/getType ^long (code-point-of ch)))
 
+(def category-names
+  "A map where general category names are indexed by the associated integer constants."
+  {Character/UPPERCASE_LETTER "Lu"
+   Character/LOWERCASE_LETTER "Ll"
+   Character/TITLECASE_LETTER "Lt"
+   Character/MODIFIER_LETTER "Lm"
+   Character/OTHER_LETTER "Lo"
+
+   Character/NON_SPACING_MARK "Mn"
+   Character/COMBINING_SPACING_MARK "Mc"
+   Character/ENCLOSING_MARK "Me"
+
+   Character/DECIMAL_DIGIT_NUMBER "Nd"
+   Character/LETTER_NUMBER "Nl"
+   Character/OTHER_NUMBER "No"
+
+   Character/CONNECTOR_PUNCTUATION "Pc"
+   Character/DASH_PUNCTUATION "Pd"
+   Character/START_PUNCTUATION "Ps"
+   Character/END_PUNCTUATION "Pe"
+   Character/INITIAL_QUOTE_PUNCTUATION "Pi"
+   Character/FINAL_QUOTE_PUNCTUATION "Pf"
+   Character/OTHER_PUNCTUATION "Po"
+
+   Character/MATH_SYMBOL "Sm"
+   Character/CURRENCY_SYMBOL "Sc"
+   Character/MODIFIER_SYMBOL "Sk"
+   Character/OTHER_SYMBOL "So"
+
+   Character/SPACE_SEPARATOR "Zs"
+   Character/LINE_SEPARATOR "Zl"
+   Character/PARAGRAPH_SEPARATOR "Zp"
+
+   Character/CONTROL "Cc"
+   Character/FORMAT "Cf"
+   Character/SURROGATE "Cs"
+   Character/PRIVATE_USE "Co"
+   Character/UNASSIGNED "Cn"})
+
+(defn category
+  "Returns the name of the general category of the given character or code point."
+  [ch]
+  (get category-names (category-int ch)))
+
 ;;; Boolean functions ;;;
 
 (defn defined?

--- a/src/djy/char.clj
+++ b/src/djy/char.clj
@@ -384,7 +384,7 @@
   (char (Character/toUpperCase ^long (code-point-of ch))))
 
 (defn title-case
-  "Converts a character to its lower-case counterpart, if it has one.
+  "Converts a character to its title-case counterpart, if it has one.
    Expects its argument to be a BMP character or code point."
   {:added "1.6"}
   [ch]

--- a/test/djy/char_test.clj
+++ b/test/djy/char_test.clj
@@ -141,6 +141,18 @@
   (prop/for-all [character gen-char]
     (string? (char/unicode-block-of character))))
 
+;;; testing category
+
+(defspec category-lower-case-letter
+  (prop/for-all [lower-case-letter gen-lower-case-letter]
+    (= (char/category lower-case-letter)
+       "Ll")))
+
+(defspec category-upper-case-letter
+  (prop/for-all [upper-case-letter gen-upper-case-letter]
+    (= (char/category upper-case-letter)
+       "Lu")))
+
 ;;; testing boolean functions
 
 (defspec defined?


### PR DESCRIPTION
`(category-int char)` wraps code used in multiple places in a function. It returns an integer value indicating the general category of the given character or code point.

`(category char)` goes a step further and returns the name of the general category of the given character or code point, e.g. "Lu" for an upper-case letter. Instead of a Java constant you get a standardized abbreviation.