### PR TITLE
Extend supplementary character support

### DIFF
--- a/src/djy/char.clj
+++ b/src/djy/char.clj
@@ -227,6 +227,7 @@
 
 (defn category
   "Returns the name of the general category of the given character or code point."
+  {:added "1.6"}
   [ch]
   (get category-names (category-int ch)))
 

--- a/src/djy/char.clj
+++ b/src/djy/char.clj
@@ -422,22 +422,19 @@
 ;;; Case conversion functions ;;;
 
 (defn lower-case
-  "Converts a character to its lower-case counterpart, if it has one.
-   Expects its argument to be a BMP character or code point."
+  "Returns the lower-case counterpart of the given character or code point."
   {:added "1.6"}
   [ch]
-  (char (Character/toLowerCase ^long (code-point-of ch))))
+  (char' (Character/toLowerCase ^long (code-point-of ch))))
 
 (defn upper-case
-  "Converts a character to its upper-case counterpart, if it has one.
-   Expects its argument to be a BMP character or code point."
+  "Returns the upper-case counterpart of the given character or code point."
   {:added "1.6"}
   [ch]
-  (char (Character/toUpperCase ^long (code-point-of ch))))
+  (char' (Character/toUpperCase ^long (code-point-of ch))))
 
 (defn title-case
-  "Converts a character to its title-case counterpart, if it has one.
-   Expects its argument to be a BMP character or code point."
+  "Returns the title-case counterpart of the given character or code point."
   {:added "1.6"}
   [ch]
-  (char (Character/toTitleCase ^long (code-point-of ch))))
+  (char' (Character/toTitleCase ^long (code-point-of ch))))

--- a/test/djy/char_test.clj
+++ b/test/djy/char_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test.check.generators :as gen]
             [clojure.test.check.properties :as prop]
             [clojure.test.check.clojure-test :refer (defspec)]
+            [clojure.test :refer [deftest is]]
             [djy.char :as char]))
 
 (def gen-bmp-char
@@ -194,3 +195,15 @@
   (prop/for-all [lower-case-letter gen-lower-case-letter]
     (= (char/upper-case lower-case-letter)
        (Character/toUpperCase lower-case-letter))))
+
+(deftest lower-case-supplementary
+  (is (= (char/lower-case "𐐄")
+         "𐐬"))
+  (is (= (char/lower-case "😀")
+         "😀")))
+
+(deftest upper-case-supplementary
+  (is (= (char/upper-case "𐐬")
+         "𐐄"))
+  (is (= (char/upper-case "😀")
+         "😀")))


### PR DESCRIPTION
`Character/toLowerCase`, `Character/toUpperCase` and `Character/toTitleCase` support code points of supplementary characters so I removed the limitation to BMP using `char'`.