### PR TITLE
Add category-major function

### DIFF
--- a/src/djy/char.clj
+++ b/src/djy/char.clj
@@ -226,10 +226,18 @@
    Character/UNASSIGNED "Cn"})
 
 (defn category
-  "Returns the name of the general category of the given character or code point."
+  "Returns the name of the general category of the given character or code point,
+   e.g. 'Nd' for a decimal number."
   {:added "1.6"}
   [ch]
   (get category-names (category-int ch)))
+
+(defn category-major
+  "Returns the name of the major general category of the given character or code point,
+   e.g. 'N' for a number."
+  {:added "1.6"}
+  [ch]
+  (subs (category ch) 0 1))
 
 ;;; Boolean functions ;;;
 

--- a/test/djy/char_test.clj
+++ b/test/djy/char_test.clj
@@ -154,6 +154,11 @@
     (= (char/category upper-case-letter)
        "Lu")))
 
+(defspec category-major-letter
+  (prop/for-all [letter gen-lower-case-letter]
+    (= (char/category-major letter)
+       "L")))
+
 ;;; testing boolean functions
 
 (defspec defined?


### PR DESCRIPTION
`(category-major ch)` returns the major category of the given character or code point, e.g. `"N"` for a number.

I'm not sure this one is worth adding.