### PR TITLE
Add `normalize` function

### DIFF
--- a/src/djy/char.clj
+++ b/src/djy/char.clj
@@ -438,3 +438,17 @@
   {:added "1.6"}
   [ch]
   (char' (Character/toTitleCase ^long (code-point-of ch))))
+
+;;; Normalization functions ;;;
+
+(def normalization-forms {:nfc java.text.Normalizer$Form/NFC
+                          :nfkc java.text.Normalizer$Form/NFKC
+                          :nfd java.text.Normalizer$Form/NFD
+                          :nfkd java.text.Normalizer$Form/NFKD})
+
+(defn normalize
+  "Normalizes the given character or string using the normalization form :nfc, :nfkc,
+   :nfd or :nfkd."
+  {:added "1.6"}
+  [s form]
+  (java.text.Normalizer/normalize (str s) (form normalization-forms)))

--- a/test/djy/char_test.clj
+++ b/test/djy/char_test.clj
@@ -207,3 +207,11 @@
          "𐐄"))
   (is (= (char/upper-case "😀")
          "😀")))
+
+;;; testing normalization
+
+(deftest normalize
+  (is (= (char/normalize "ô" :nfd)
+         "ô"))
+  (is (= (char/normalize "ô" :nfc)
+         "ô")))


### PR DESCRIPTION
`(normalize s form)` normalizes the given character or string using the normalization form `:nfc`, `:nfkc`, `:nfd` or `:nfkd`, which helps in dealing with equivalent code points.